### PR TITLE
fixes-issue-with-path-and-whitespaces

### DIFF
--- a/lib/retina_rails/processors/carrierwave.rb
+++ b/lib/retina_rails/processors/carrierwave.rb
@@ -9,7 +9,7 @@ module RetinaRails
       #
       def store_retina_dimensions
         if model
-          width, height = `identify -format "%wx%h" #{file.path}`.split(/x/) ## Read dimensions
+          width, height = `identify -format "%wx%h" '#{file.path}'`.split(/x/) ## Read dimensions
 
           ## Set original height and width attributes on model
 

--- a/lib/retina_rails/processors/paperclip.rb
+++ b/lib/retina_rails/processors/paperclip.rb
@@ -10,7 +10,7 @@ module Paperclip
       style     = options[:style]
 
       if file_path
-        width, height = `identify -format "%wx%h" #{file_path}`.split(/x/) ## Read dimensions
+        width, height = `identify -format "%wx%h" '#{file_path}'`.split(/x/) ## Read dimensions
 
         ## Set original height and width attributes on model
         model.retina_dimensions = (model.retina_dimensions || {}).deep_merge!(


### PR DESCRIPTION
I was having issues with the gem not saving the retina_dimensions properly (it was always width: 0, height:0), and it was because the file.path had folders with whitespaces, so the command `identify -format "%wx%h" #{file.path}` was raising an error. I was able to easily fix it by adding single quotes around the path.
