### PR TITLE
[INTERNAL] Add support for latest version of Carrierwave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.1
-  - 2.1.3
+  - 2.1.7
+  - 2.2.3
   - ruby-head
 
 env:
-  - "RAILS_VERSION=3.1.0"
-  - "RAILS_VERSION=3.2.0"
-  - "RAILS_VERSION=4.0.0"
-  - "RAILS_VERSION=4.1.0"
+  - "RAILS_VERSION=3.1.12"
+  - "RAILS_VERSION=3.2.22"
+  - "RAILS_VERSION=4.0.13"
+  - "RAILS_VERSION=4.1.14"
+  - "RAILS_VERSION=4.2.5"
   - "RAILS_VERSION=master"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+bundler_args: "--jobs 4 --retry 3"
+cache: bundler
 language: ruby
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0
@@ -18,3 +21,4 @@ matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"
     - rvm: ruby-head
+  fast_finish: true

--- a/lib/retina_rails/strategies/carrierwave.rb
+++ b/lib/retina_rails/strategies/carrierwave.rb
@@ -65,7 +65,11 @@ module RetinaRails
             config = versions[name]
             options[:retina] = false
 
-            processors = config[:uploader].processors.dup
+            processors = if config.respond_to?(:processors)
+                           config.processors.dup
+                         else
+                           config[:uploader].processors.dup
+                         end
             dimensions_processor = nil
 
             ## Check if there's a resize processor to get the dimensions
@@ -86,7 +90,11 @@ module RetinaRails
               dimensions.insert(0, width)
 
               ## Reset the processors
-              versions[name][:uploader].processors = []
+              if config.respond_to?(:processors)
+                config.processors = []
+              else
+                config[:uploader].processors = []
+              end
 
               ## Override version with double height and width
               version name, options do

--- a/retina_rails.gemspec
+++ b/retina_rails.gemspec
@@ -27,11 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rmagick'
   gem.add_development_dependency 'sqlite3'
 
-  if RUBY_VERSION > '1.9.2'
-    gem.add_dependency 'rails', '>= 3.2.0'
-  else
-    gem.add_dependency 'rails', '>= 3.2.0', '< 4.0.0'
-  end
+  gem.add_dependency 'rails', '>= 3.2.0'
 
   if File.exists?('UPGRADING')
     gem.post_install_message = File.read("UPGRADING")

--- a/retina_rails.gemspec
+++ b/retina_rails.gemspec
@@ -19,14 +19,13 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'bundler', '>= 1.0.0'
-  gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rspec', '>= 2.3'
-  gem.add_development_dependency 'rspec-rails', '~> 2.0'
+  gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'carrierwave'
   gem.add_development_dependency 'paperclip'
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rspec-rails', '~> 3.4'
   gem.add_development_dependency 'rmagick'
   gem.add_development_dependency 'sqlite3'
-  gem.add_development_dependency 'coveralls'
 
   if RUBY_VERSION > '1.9.2'
     gem.add_dependency 'rails', '>= 3.2.0'

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -40,56 +40,58 @@ describe ActionView::Helpers::AssetTagHelper, :type => :helper do
       it 'should set correct width and height' do
         image = helper.retina_image_tag(Upload.new, :avatar, :small)
 
-        image.should include('width="40"')
-        image.should include('height="30"')
+        expect(image).to include('width="40"')
+        expect(image).to include('height="30"')
       end
 
       it 'should be able to add a class' do
         image = helper.retina_image_tag(Upload.new, :avatar, :small, :class => 'foo')
-        image.should include('class="foo"')
+        expect(image).to include('class="foo"')
       end
 
     end
 
     context 'without dimensions present' do
 
-      before(:each) { Upload.any_instance.stub(:retina_dimensions).and_return(nil) }
+      before(:each) do
+        allow_any_instance_of(Upload).to receive(:retina_dimensions).and_return(nil)
+      end
 
       it 'should set correct width and height' do
         image = helper.retina_image_tag(Upload.new, :avatar, :small, :default => { :width => 25, :height => 40 })
 
-        image.should include('width="25"')
-        image.should include('height="40"')
+        expect(image).to include('width="25"')
+        expect(image).to include('height="40"')
 
         image = helper.retina_image_tag(Upload.new, :avatar, :small, :default => [25, 40])
 
-        image.should include('width="25"')
-        image.should include('height="40"')
+        expect(image).to include('width="25"')
+        expect(image).to include('height="40"')
       end
 
       it 'should set no height and width if no defaults present' do
         image = helper.retina_image_tag(Upload.new, :avatar, :small)
 
-        image.should_not include('width')
-        image.should_not include('height')
+        expect(image).to_not include('width')
+        expect(image).to_not include('height')
       end
 
       it 'should be able to add a class' do
         image = helper.retina_image_tag(Upload.new, :avatar, :small, :default => { :width => 25, :height => 40 }, :class => 'foo')
 
-        image.should include('class="foo"')
+        expect(image).to include('class="foo"')
       end
 
       it 'should strip default attributes' do
         image = helper.retina_image_tag(Upload.new, :avatar, :small, :default => { :width => 25, :height => 40 })
 
-        image.should_not include('default')
+        expect(image).to_not include('default')
       end
 
       it 'should respect other options' do
         image = helper.retina_image_tag(Upload.new, :avatar, :small, :default => { :width => 25, :height => 40 }, :alt => 'Some alt tag')
 
-        image.should include('alt="Some alt tag"')
+        expect(image).to include('alt="Some alt tag"')
       end
 
     end
@@ -99,14 +101,14 @@ describe ActionView::Helpers::AssetTagHelper, :type => :helper do
   describe '#image_tag' do
 
     it 'should show a deprecation warning when used with retina option' do
-      ActiveSupport::Deprecation.should_receive(:warn)
+      expect(ActiveSupport::Deprecation).to receive(:warn)
         .with("`image_tag('image.png', :retina => true)` is deprecated use `retina_image_tag` instead")
 
       image_tag('image.png', :retina => true)
     end
 
     it 'should not show a deprecation warning when used without retina option' do
-      ActiveSupport::Deprecation.should_not_receive(:warn)
+      expect(ActiveSupport::Deprecation).to_not receive(:warn)
         .with("`image_tag('image.png', :retina => true)` is deprecated use `retina_image_tag` instead")
 
       image_tag('image.png')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require 'carrierwave'
 require 'paperclip'
 require "paperclip/railtie"
 Paperclip::Railtie.insert
+Paperclip.options[:log] = false unless ENV["LOG_PAPERCLIP"]
 
 ## Setup fixture database for activerecord
 

--- a/spec/strategies/carrierwave_spec.rb
+++ b/spec/strategies/carrierwave_spec.rb
@@ -19,7 +19,14 @@ describe RetinaRails::Strategies::CarrierWave do
   after(:each) do
     AnonymousUploader.enable_processing = false
     @uploader.remove!
-    AnonymousUploader.versions[:small][:uploader].processors = [] ## Reset processors
+
+    ## Reset processors
+    version = AnonymousUploader.versions[:small]
+    if version.respond_to?(:processors)
+      version.processors = []
+    else
+      version[:uploader].processors = []
+    end
   end
 
   ##

--- a/spec/strategies/carrierwave_spec.rb
+++ b/spec/strategies/carrierwave_spec.rb
@@ -40,16 +40,16 @@ describe RetinaRails::Strategies::CarrierWave do
     end
 
     it 'should double the height and width of an image' do
-      @uploader.small.should have_dimensions(60, 80)
+      expect(@uploader.small).to have_dimensions(60, 80)
     end
 
     it 'should store original width and height attributes for version' do
-      @uploader.model.retina_dimensions[:avatar][:small].should == { :width => 30, :height => 40 }
+      expect(@uploader.model.retina_dimensions[:avatar][:small]).to eq({ :width => 30, :height => 40 })
     end
 
     it "should set quality to it's default 60%" do
       quality = Magick::Image.read(@uploader.small.current_path).first.quality
-      quality.should == 60
+      expect(quality).to eq(60)
     end
 
   end
@@ -71,11 +71,11 @@ describe RetinaRails::Strategies::CarrierWave do
     it "should override quality" do
       upload!
       quality = Magick::Image.read(@uploader.small.current_path).first.quality
-      quality.should == 80
+      expect(quality).to eq 80
     end
 
     it 'should receive quality processor once' do
-      AnonymousUploader.any_instance.should_receive(:retina_quality).once
+      expect_any_instance_of(AnonymousUploader).to receive(:retina_quality).once
 
       upload!
     end
@@ -105,11 +105,11 @@ describe RetinaRails::Strategies::CarrierWave do
     end
 
     it 'should double the height and width of an image' do
-      @uploader.small.should have_dimensions(60, 80)
+      expect(@uploader.small).to have_dimensions(60, 80)
     end
 
     it 'should store original width and height attributes for version' do
-      @uploader.model.retina_dimensions[:avatar][:small].should == { :width => 30, :height => 40 }
+      expect(@uploader.model.retina_dimensions[:avatar][:small]).to eq({ :width => 30, :height => 40 })
     end
 
   end
@@ -137,11 +137,11 @@ describe RetinaRails::Strategies::CarrierWave do
     end
 
     it 'should double the height and width of an image' do
-      @uploader.small.should have_dimensions(200, 200)
+      expect(@uploader.small).to have_dimensions(200, 200)
     end
 
     it 'should store original width and height attributes for version' do
-      @uploader.model.retina_dimensions[:avatar][:small].should == { :width => 100, :height => 100 }
+      expect(@uploader.model.retina_dimensions[:avatar][:small]).to eq({ :width => 100, :height => 100 })
     end
 
   end
@@ -162,8 +162,8 @@ describe RetinaRails::Strategies::CarrierWave do
     end
 
     it 'should not create a version' do
-      @uploader.version_exists?(:small_conditional).should be_false
-      @uploader.small_conditional.current_path.should_not be_present
+      expect(@uploader.version_exists?(:small_conditional)).to eq(false)
+      expect(@uploader.small_conditional.current_path).to_not be_present
     end
 
   end

--- a/spec/strategies/paperclip_spec.rb
+++ b/spec/strategies/paperclip_spec.rb
@@ -38,16 +38,16 @@ describe RetinaRails::Strategies::Paperclip do
     end
 
     it 'should double the height and width of an image' do
-      Paperclip::Geometry.from_file(image_path).to_s.should == '60x80'
+      expect(Paperclip::Geometry.from_file(image_path).to_s).to eq('60x80')
     end
 
     it 'should store original width and height attributes for version' do
-      @upload.retina_dimensions[:avatar][:big].should == { :width => 30, :height => 40 }
+      expect(@upload.retina_dimensions[:avatar][:big]).to eq({ :width => 30, :height => 40 })
     end
 
     it "should set quality to it's default 60%" do
       quality = Magick::Image.read(image_path).first.quality
-      quality.should == 60
+      expect(quality).to eq(60)
     end
 
   end
@@ -75,16 +75,16 @@ describe RetinaRails::Strategies::Paperclip do
     end
 
     it 'should double the height and width of an image' do
-      Paperclip::Geometry.from_file(image_path).to_s.should == '60x80'
+      expect(Paperclip::Geometry.from_file(image_path).to_s).to eq('60x80')
     end
 
     it 'should store original width and height attributes for version' do
-      @upload.retina_dimensions[:avatar][:big].should == { :width => 30, :height => 40 }
+      expect(@upload.retina_dimensions[:avatar][:big]).to eq({ :width => 30, :height => 40 })
     end
 
     it "should set quality to it's default 60%" do
       quality = Magick::Image.read(image_path).first.quality
-      quality.should == 60
+      expect(quality).to eq(60)
     end
 
   end
@@ -103,16 +103,16 @@ describe RetinaRails::Strategies::Paperclip do
     end
 
     it 'should double the height and width of an image' do
-      Paperclip::Geometry.from_file(image_path).to_s.should == '1600x1600'
+      expect(Paperclip::Geometry.from_file(image_path).to_s).to eq('1600x1600')
     end
 
     it 'should store original width and height attributes for version' do
-      @upload.retina_dimensions[:avatar][:big].should == { :width => 800, :height => 800 }
+      expect(@upload.retina_dimensions[:avatar][:big]).to eq({ :width => 800, :height => 800 })
     end
 
     it "should set quality to it's default 60%" do
       quality = Magick::Image.read(image_path).first.quality
-      quality.should == 60
+      expect(quality).to eq(60)
     end
 
   end
@@ -133,7 +133,7 @@ describe RetinaRails::Strategies::Paperclip do
 
     it "should set quality" do
       quality = Magick::Image.read(image_path).first.quality
-      quality.should == 25
+      expect(quality).to eq(25)
     end
 
   end

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -7,10 +7,12 @@ module RetinaRailsTest
     config.active_support.deprecation = :log
 
     if Rails::VERSION::STRING >= "4.0.0"
+      config.eager_load      = false
       config.secret_token    = 'existing secret token'
       config.secret_key_base = 'new secret key base'
     end
 
   end
 end
+
 RetinaRailsTest::Application.initialize!


### PR DESCRIPTION
Carrierwave is currently undergoing some internal refactoring on the path to the 1.0 release, and `retina_rails` is currently broken when used with the latest version. This PR ensures support for both existing, as well as upcoming, versions of Carrierwave.

RSpec has also been updated to the latest version, and the syntax updated to use the newer `expect`-style implementation. While not strictly _necessary_, it made these updates a bit easier to implement and test.
